### PR TITLE
Enable C language support in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('hdoc', 'cpp', version: '1.2.2', default_options: ['cpp_std=c++17', 'warning_level=3'])
+project('hdoc', 'cpp', 'c', version: '1.2.2', default_options: ['cpp_std=c++17', 'warning_level=3'])
 
 dep_llvm = dependency('LLVM', include_type: 'system')
 clang_modules = [


### PR DESCRIPTION
When I tried creating a [Dockerfile to build hdoc](https://github.com/foxglove/mcap/blob/main/cpp/hdoc.Dockerfile), I found that the CMake steps failed because C language support was not enabled. Adding `'c'` to this list makes things work.

Example failure: https://gist.github.com/jtbandes/b5eea7b8543fa3c1681dda1837e6a0a0

```
Determining dependency 'LLVM' with CMake executable '/usr/bin/cmake'
Try CMake generator: Ninja

...

CMake failed for generator Ninja and package LLVM with error code 1
OUT:

...

-- Could NOT find FFI (missing: HAVE_FFI_CALL) 
-- Could NOT find Terminfo (missing: Terminfo_LINKABLE) 
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Found LibXml2: /usr/lib/aarch64-linux-gnu/libxml2.so (found version "2.9.13") 
-- Configuring incomplete, errors occurred!
See also "/hdoc/build/meson-private/cmake_LLVM/CMakeFiles/CMakeOutput.log".

ERR:
CMake Error at /usr/share/cmake-3.22/Modules/Internal/CheckSourceCompiles.cmake:44 (message):
  check_source_compiles: C: needs to be enabled before use.
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/CheckCSourceCompiles.cmake:76 (cmake_check_source_compiles)
  /usr/lib/llvm-14/cmake/FindFFI.cmake:44 (check_c_source_compiles)
  /usr/lib/llvm-14/cmake/LLVMConfig.cmake:242 (find_package)
  CMakeLists.txt:9 (find_package)


CMake Error at /usr/share/cmake-3.22/Modules/Internal/CheckSourceCompiles.cmake:44 (message):
  check_source_compiles: C: needs to be enabled before use.
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/CheckCSourceCompiles.cmake:76 (cmake_check_source_compiles)
  /usr/lib/llvm-14/cmake/FindTerminfo.cmake:21 (check_c_source_compiles)
  /usr/lib/llvm-14/cmake/LLVMConfig.cmake:249 (find_package)
  CMakeLists.txt:9 (find_package)
```