### PR TITLE
Fix crash with empty @param

### DIFF
--- a/src/indexer/MatcherUtils.cpp
+++ b/src/indexer/MatcherUtils.cpp
@@ -47,6 +47,10 @@ static llvm::Optional<std::string> getCanonicalPath(const clang::Decl* d) {
   return path.str().str();
 }
 
+template <typename T> static bool isParamAndHasName(T* param) {
+  return param != nullptr && param->hasParamName();
+}
+
 /// This is used across all types of symbols (Function, Record, Namespace, etc.) to get the
 /// vital information of the symbol
 void fillOutSymbol(hdoc::types::Symbol& s, const clang::NamedDecl* d, const std::filesystem::path& rootDir) {
@@ -327,7 +331,8 @@ void processRecordComment(hdoc::types::RecordSymbol&      cs,
       }
     }
 
-    if (const auto* tParamComment = llvm::dyn_cast<clang::comments::TParamCommandComment>(*c)) {
+    if (const auto* tParamComment = llvm::dyn_cast<clang::comments::TParamCommandComment>(*c);
+        isParamAndHasName(tParamComment)) {
       const std::string tParamName = tParamComment->getParamNameAsWritten().str();
       for (auto& tparam : cs.templateParams) {
         if (tparam.name == tParamName) {
@@ -380,7 +385,8 @@ void processFunctionComment(hdoc::types::FunctionSymbol&    f,
     }
 
     // Match function parameter names with params in FunctionSymbol
-    if (const auto* paramComment = llvm::dyn_cast<clang::comments::ParamCommandComment>(*c)) {
+    if (const auto* paramComment = llvm::dyn_cast<clang::comments::ParamCommandComment>(*c);
+        isParamAndHasName(paramComment)) {
       const std::string paramName = paramComment->getParamNameAsWritten().str();
       for (auto& param : f.params) {
         if (param.name == paramName) {
@@ -389,7 +395,8 @@ void processFunctionComment(hdoc::types::FunctionSymbol&    f,
       }
     }
 
-    if (const auto* tParamComment = llvm::dyn_cast<clang::comments::TParamCommandComment>(*c)) {
+    if (const auto* tParamComment = llvm::dyn_cast<clang::comments::TParamCommandComment>(*c);
+        isParamAndHasName(tParamComment)) {
       const std::string tParamName = tParamComment->getParamNameAsWritten().str();
       for (auto& tparam : f.templateParams) {
         if (tparam.name == tParamName) {

--- a/tests/index-tests/test-comments-functions.cpp
+++ b/tests/index-tests/test-comments-functions.cpp
@@ -385,3 +385,21 @@ TEST_CASE("Function has math commands in function and parameter names") {
   CHECK(s.params[3].docComment == R"($\sqrt{y_2}$)");
   CHECK(s.params[3].defaultValue == "");
 }
+
+TEST_CASE("Function with empty parameter comment") {
+  const std::string code = R"(
+    /// @brief does foo to x
+    ///
+    /// @param x bar
+    /// @param
+    /// @returns boo
+    int foo(int x);
+  )";
+
+  const hdoc::types::Index index = runOverCode(code);
+  checkIndexSizes(index, 0, 1, 0, 0);
+
+  hdoc::types::FunctionSymbol s = index.functions.entries.begin()->second;
+  CHECK(s.name == "foo");
+  CHECK(s.params.size() == 1);
+}

--- a/tests/index-tests/test-comments-templates.cpp
+++ b/tests/index-tests/test-comments-templates.cpp
@@ -203,3 +203,19 @@ TEST_CASE("Test a templated class with multiple tparam comments") {
   CHECK(s.templateParams[1].isParameterPack == false);
   CHECK(s.templateParams[1].isTypename == false);
 }
+
+TEST_CASE("Test a templated class with an empty tparam comment") {
+  const std::string code = R"(
+    /// \brief decoy brief comment
+    /// \tparam T1 a comment
+    /// \tparam
+    template <class T1> class Test {};
+  )";
+
+  const hdoc::types::Index index = runOverCode(code);
+  checkIndexSizes(index, 1, 0, 0, 0);
+
+  hdoc::types::RecordSymbol s = index.records.entries.begin()->second;
+  CHECK(s.name == "Test");
+  CHECK(s.templateParams.size() == 1);
+}


### PR DESCRIPTION
Clang 14 crashes if getParamNameAsWritten() is called without
first checking whether it exists.