### PR TITLE
Compilation fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,8 +44,12 @@ asset_files = [
 ]
 gen = generator(find_program('xxd'),
                 output: '@PLAINNAME@.cpp',
-                arguments: ['-i', '@INPUT@', '@OUTPUT@'])
-assets_src = gen.process(asset_files)
+                arguments: ['-i', '-name', '@EXTRA_ARGS@', '@INPUT@', '@OUTPUT@'])
+assets_src = []
+
+foreach asset_file : asset_files
+	assets_src += gen.process(asset_file, extra_args: '___' + asset_file.underscorify())
+endforeach
 
 # Enable SSL support
 add_project_arguments('-DCPPHTTPLIB_OPENSSL_SUPPORT', language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -1,16 +1,22 @@
 project('hdoc', 'c', 'cpp', version: '1.3.2', default_options: ['cpp_std=c++20', 'warning_level=3'])
 
 dep_llvm = dependency('LLVM', include_type: 'system')
-clang_modules = [
-  'clangTooling',
-  'clangToolingInclusions',
-  'clangToolingCore',
-  'clangFrontend',
-  'clangAST',
-  'clangIndex',
-  'clangBasic',
-]
-dep_clang = dependency('Clang', include_type: 'system', method: 'cmake', modules: clang_modules)
+
+llvm_libdir = dep_llvm.get_variable(cmake: 'LLVM_LIBRARY_DIR', configtool: 'libdir')
+dep_clang = meson.get_compiler('cpp').find_library('clang-cpp', dirs : llvm_libdir, required : false)
+
+if not dep_clang.found()
+  clang_modules = [
+    'clangTooling',
+    'clangToolingInclusions',
+    'clangToolingCore',
+    'clangFrontend',
+    'clangAST',
+    'clangIndex',
+    'clangBasic',
+  ]
+  dep_clang = dependency('Clang', include_type: 'system', method: 'cmake', modules: clang_modules)
+endif
 
 # Disable RTTI
 add_project_arguments('-fno-rtti', language: 'cpp')


### PR DESCRIPTION
Compiling current master on Arch Linux fails for two reasons, both of which this PR addresses:

- `argparse.hpp` currently does not include `<utility>`, which results in an compilation error; this is fixed by bumping it to v2.9.
- Arch Linux ships it clang libraries as `clang-cpp` (as do some other distros), so that meson can't find the libraries; this is fixed by defaulting to using `clang-cpp`, but falling back to the old method. This is the same approach as used by `mesa`.