### PR TITLE
fix ignore.ignore_private_members=false being interpreted as =true

### DIFF
--- a/src/frontend/Frontend.cpp
+++ b/src/frontend/Frontend.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -213,8 +214,8 @@ hdoc::frontend::Frontend::Frontend(int argc, char** argv, hdoc::types::Config* c
     }
   }
 
-  if (const auto& ignorePrivateMembers = toml["ignore"]["ignore_private_members"].as_boolean()) {
-    cfg->ignorePrivateMembers = ignorePrivateMembers;
+  if (std::optional<bool> ignorePrivateMembers = toml["ignore"]["ignore_private_members"].value<bool>()) {
+    cfg->ignorePrivateMembers = *ignorePrivateMembers;
   }
 
   // Collect paths to markdown files


### PR DESCRIPTION
If the user specifies 'ignore.ignore_private_members=false' in their .hdoc.toml, we are interpreting that as if they wrote 'ignore.ignore_private_members=true'. This is because .as_boolean returns a pointer, and we are casting that non-null pointer to a boolean, which always yields true.

Fix the problem:

* Avoid auto, which made the problem harder to see
* Use .value<bool>() (which returns a std::optional<bool>) instead of .as_boolean() (which returns a toml::value<bool>*)
* Use * to extract the value from the std::optional<bool> (which the compiler helpfully now tells us to do)