### PR TITLE
Add a `project.git_default_branch` option

### DIFF
--- a/.hdoc.toml
+++ b/.hdoc.toml
@@ -1,7 +1,8 @@
 [project]
 name = "hdoc"
 version = "1.3.2"
-git_repo_url = "https://github.com/hdoc/hdoc/blob/master/"
+git_repo_url = "https://github.com/hdoc/hdoc/"
+git_default_branch = "master"
 
 [paths]
 compile_commands = "build/compile_commands.json"

--- a/site/content/docs/reference/config-file-reference.md
+++ b/site/content/docs/reference/config-file-reference.md
@@ -58,17 +58,29 @@ num_threads = 8
 URL to a GitHub or GitLab repository where source code for the current project is stored.
 This is used to link functions, records, and enums to their original declarations in the source code.
 The URL must end with a trailing slash, and include a commit hash or branch designation.
-The commit hash can be used to pin the documentation to a given version of the code, while using a branch designation (such as "main") will use the latest commit on that branch for all links.
 The value is a string, and is optional.
 If the value is not supplied, declarations will not be linked back to the source code.
 
 ```toml
 [project]
-# Use the latest commit on the main branch
-git_repo_url = "https://github.com/hdoc/hdoc/blob/main/"
+git_repo_url = "https://github.com/hdoc/hdoc/"
+```
+
+### `git_default_branch`
+
+The name of the branch to use when linking to definitions on GitHub or GitLab.
+A commit hash or a tag can be used instead to pin the documentation to a given version of the code, while using a branch designation (such as "main") will use the latest commit on that branch for all links.
+The value is a string, and is optional.
+If the value is not supplied, declarations will not be linked back to the source code.
+
+```toml
+git_default_branch = "master"
 
 # Alternatively, pin all links to the 3d9b3c0... commit
-# git_repo_url = "https://github.com/hdoc/hdoc/blob/3d9b3c0f6d21b7dc79318da394afcdd2d3e077cc/"
+# git_default_branch = "3d9b3c0f6d21b7dc79318da394afcdd2d3e077cc"
+
+# Or pin all links to the 1.3.2 tag
+# git_default_branch = "1.3.2"
 ```
 
 ## `paths`

--- a/src/frontend/Frontend.cpp
+++ b/src/frontend/Frontend.cpp
@@ -98,6 +98,7 @@ hdoc::frontend::Frontend::Frontend(int argc, char** argv, hdoc::types::Config* c
   cfg->projectName    = toml["project"]["name"].value_or("");
   cfg->projectVersion = toml["project"]["version"].value_or("");
   cfg->gitRepoURL     = toml["project"]["git_repo_url"].value_or("");
+  cfg->gitDefaultBranch = toml["project"]["git_default_branch"].value_or("");
   if (cfg->projectName == "") {
     spdlog::error("Project name in .hdoc.toml is empty, not a string, or invalid.");
     return;

--- a/src/serde/HTMLWriter.cpp
+++ b/src/serde/HTMLWriter.cpp
@@ -397,13 +397,13 @@ static std::string getHyperlinkedTypeName(const hdoc::types::TypeRef& type) {
 /// Returns an HTML node indicating where the s is declared.
 /// A hyperlink to the exact line in the source file (for GitHub and GitLab) is returned
 /// if gitRepoURL is provided.
-static CTML::Node getDeclaredAtNode(const hdoc::types::Symbol& s, const std::string_view gitRepoURL = "") {
+static CTML::Node getDeclaredAtNode(const hdoc::types::Symbol& s, const std::string_view gitRepoURL = "", const std::string_view gitDefaultBranch = "") {
   auto p = CTML::Node("p", "Declared at: ");
   if (gitRepoURL == "") {
     return p.AddChild(CTML::Node("span.is-family-code", s.file + ":" + std::to_string(s.line)));
   } else {
     return p.AddChild(CTML::Node("a.is-family-code", s.file + ":" + std::to_string(s.line))
-                          .SetAttr("href", std::string(gitRepoURL) + s.file + "#L" + std::to_string(s.line)));
+                          .SetAttr("href", std::string(gitRepoURL) + "blob/" + std::string(gitDefaultBranch) + "/" + s.file + "#L" + std::to_string(s.line)));
   }
 }
 
@@ -468,7 +468,7 @@ getBreadcrumbNode(const std::string& prefix, const hdoc::types::Symbol& s, const
 }
 
 /// Print a function to main
-static void printFunction(const hdoc::types::FunctionSymbol& f, CTML::Node& main, const std::string_view gitRepoURL) {
+static void printFunction(const hdoc::types::FunctionSymbol& f, CTML::Node& main, const std::string_view gitRepoURL, const std::string_view gitDefaultBranch) {
   // Print function return type, name, and parameters as section header
   std::string proto = hdoc::serde::getHyperlinkedFunctionProto(hdoc::serde::clangFormat(f.proto), f);
   auto        inner = CTML::Node("code.hdoc-function-code.language-cpp").AppendRawHTML(proto);
@@ -490,7 +490,7 @@ static void printFunction(const hdoc::types::FunctionSymbol& f, CTML::Node& main
   if (f.docComment != "") {
     main.AddChild(CTML::Node("p", f.docComment));
   }
-  main.AddChild(getDeclaredAtNode(f, gitRepoURL));
+  main.AddChild(getDeclaredAtNode(f, gitRepoURL, gitDefaultBranch));
 
   // Print function parameters (with type, name, default value, and comment) as a list
   if (f.templateParams.size() > 0) {
@@ -559,7 +559,7 @@ void hdoc::serde::HTMLWriter::printFunctions() const {
     CTML::Node page("main");
     this->pool.async(
         [&](const hdoc::types::FunctionSymbol& func, CTML::Node pg) {
-          printFunction(func, pg, this->cfg->gitRepoURL);
+          printFunction(func, pg, this->cfg->gitRepoURL, this->cfg->gitDefaultBranch);
           printNewPage(*this->cfg,
                        pg,
                        this->cfg->outputDir / func.url(),
@@ -714,7 +714,7 @@ void hdoc::serde::HTMLWriter::printRecord(const hdoc::types::RecordSymbol& c) co
   if (c.docComment != "") {
     main.AddChild(CTML::Node("p", c.docComment));
   }
-  main.AddChild(getDeclaredAtNode(c, this->cfg->gitRepoURL));
+  main.AddChild(getDeclaredAtNode(c, this->cfg->gitRepoURL, this->cfg->gitDefaultBranch));
 
   // Base records
   uint64_t count = 0;
@@ -817,7 +817,7 @@ void hdoc::serde::HTMLWriter::printRecord(const hdoc::types::RecordSymbol& c) co
       if (index->functions.contains(methodID) == false) {
         continue;
       }
-      printFunction(this->index->functions.entries.at(methodID), main, this->cfg->gitRepoURL);
+      printFunction(this->index->functions.entries.at(methodID), main, this->cfg->gitRepoURL, this->cfg->gitDefaultBranch);
     }
   }
 
@@ -925,7 +925,7 @@ void hdoc::serde::HTMLWriter::printEnum(const hdoc::types::EnumSymbol& e) const 
   if (e.docComment != "") {
     main.AddChild(CTML::Node("p", e.docComment));
   }
-  main.AddChild(getDeclaredAtNode(e, this->cfg->gitRepoURL));
+  main.AddChild(getDeclaredAtNode(e, this->cfg->gitRepoURL, this->cfg->gitDefaultBranch));
 
   // Enum members in table format
   main.AddChild(CTML::Node("h2", "Enumerators"));

--- a/src/types/Config.hpp
+++ b/src/types/Config.hpp
@@ -31,6 +31,7 @@ struct Config {
   std::string              timestamp;                    ///< Timestamp of this run
   std::string              hdocVersion;                  ///< hdoc git commit hash
   std::string              gitRepoURL;                   ///< URL prefix of a GitHub or GitLab repo for source links
+  std::string              gitDefaultBranch;             ///< default branch of the git repo
   std::vector<std::string> includePaths;                 ///< Include paths passed on to Clang
   std::vector<std::string> ignorePaths;                  ///< Paths from which matches should be ignored
   bool                     ignorePrivateMembers = false; ///< Should private members of records be ignored?


### PR DESCRIPTION
This allows for specifying the repository base URL separately from the branch/commit/tag part, which fixes the `Repository` link in the sidebar while preserving the functionality of the links to declarations, all while being more user-friendly IMO.

The configuration in `.hdoc.toml` would look like this:
```toml
git_repo_url = "https://github.com/hdoc/hdoc/"
git_default_branch = "master"
```