### PR TITLE
Fixing compatibility with llvm 16. 

### DIFF
--- a/src/frontend/Frontend.cpp
+++ b/src/frontend/Frontend.cpp
@@ -151,10 +151,10 @@ hdoc::frontend::Frontend::Frontend(int argc, char** argv, hdoc::types::Config* c
     // The actual output we care about goes to tempFile, and we use /dev/null as a stand-in for the file the compiler
     // reads.
     llvm::SmallVector<llvm::StringRef> compilerFlags = {compilerPath.get(), "-E", "-Wp,-v", "-xc++", "/dev/null"};
-    llvm::Optional<llvm::StringRef>    redirects[]   = {llvm::None, {"/dev/null"}, {tempFile}}; // stdin, stdout, stderr
+    std::optional<llvm::StringRef>    redirects[]   = {std::nullopt, {"/dev/null"}, {tempFile}}; // stdin, stdout, stderr
 
     std::string errMsg = "";
-    int rc = llvm::sys::ExecuteAndWait(compilerPath.get(), compilerFlags, llvm::None, redirects, 10, 0, &errMsg);
+    int rc = llvm::sys::ExecuteAndWait(compilerPath.get(), compilerFlags, std::nullopt, redirects, 10, 0, &errMsg);
     if (rc != 0) {
       spdlog::error("Failed to determine the system include paths ({}, {}).", rc, errMsg);
       return;


### PR DESCRIPTION
Following this [issue](https://github.com/hdoc/hdoc/issues/42) I prepared this easy fix. 

I tested it with clang 14.0.0 and both llvm 14 and llvm 16. 

Hope you find it useful!

Best
Riccardo