### PR TITLE
Implement a `input_dir` config option to allow for non-CWD source trees

### DIFF
--- a/site/content/docs/reference/config-file-reference.md
+++ b/site/content/docs/reference/config-file-reference.md
@@ -114,6 +114,17 @@ It is required for full versions of hdoc, but optional for "client" versions of 
 output_dir = "docs/hdoc-output"
 ```
 
+### `input_dir`
+
+hdoc discards source files that are located outside of input directory or its subdirectories.
+Specifying `input_dir` allows for having the configuration file separate from your sources, if desired.
+If no `input_dir` is specified, it defaults to the CWD.
+
+```toml
+[paths]
+input_dir = "/path/to/your/source/root"
+```
+
 ## `includes`
 
 The includes section allows for finer-grained control of how hdoc finds included files.

--- a/src/frontend/Frontend.cpp
+++ b/src/frontend/Frontend.cpp
@@ -96,6 +96,7 @@ hdoc::frontend::Frontend::Frontend(int argc, char** argv, hdoc::types::Config* c
 
   // Get other arguments from the .hdoc.toml file.
   cfg->outputDir        = std::filesystem::path(toml["paths"]["output_dir"].value_or(""));
+  cfg->inputDir         = std::filesystem::path(toml["paths"]["input_dir"].value_or(cfg->rootDir.string()));
   cfg->projectName      = toml["project"]["name"].value_or("");
   cfg->projectVersion   = toml["project"]["version"].value_or("");
   cfg->gitRepoURL       = toml["project"]["git_repo_url"].value_or("");

--- a/src/indexer/Indexer.cpp
+++ b/src/indexer/Indexer.cpp
@@ -53,7 +53,7 @@ void hdoc::indexer::Indexer::run() {
     includePaths.emplace_back("-isystem" + d);
   }
 
-  hdoc::indexer::ParallelExecutor tool(*cmpdb, includePaths, this->pool, this->cfg->debugLimitNumIndexedFiles);
+  hdoc::indexer::ParallelExecutor tool(*cmpdb, includePaths, this->pool, *this->cfg);
   tool.execute(clang::tooling::newFrontendActionFactory(&Finder));
 }
 

--- a/src/indexer/MatcherUtils.cpp
+++ b/src/indexer/MatcherUtils.cpp
@@ -53,7 +53,7 @@ template <typename T> static bool isParamAndHasName(const T* param) {
 
 /// This is used across all types of symbols (Function, Record, Namespace, etc.) to get the
 /// vital information of the symbol
-void fillOutSymbol(hdoc::types::Symbol& s, const clang::NamedDecl* d, const std::filesystem::path& rootDir) {
+void fillOutSymbol(hdoc::types::Symbol& s, const clang::NamedDecl* d, const std::filesystem::path& inputDir) {
   s.name = d->getNameAsString();
   s.line = d->getASTContext().getSourceManager().getSpellingLineNumber(d->getLocation());
 
@@ -62,7 +62,7 @@ void fillOutSymbol(hdoc::types::Symbol& s, const clang::NamedDecl* d, const std:
     spdlog::warn("Unable to get absolute path for {}", s.name);
     return;
   }
-  s.file = std::filesystem::relative(*absPath, rootDir).string();
+  s.file = std::filesystem::relative(*absPath, inputDir).string();
 }
 
 /// @brief If the type is a specialized template, convert it to the original non-specialized
@@ -96,7 +96,7 @@ void findParentNamespace(hdoc::types::Symbol& s, const clang::NamedDecl* d) {
 
 bool isInIgnoreList(const clang::Decl*              d,
                     const std::vector<std::string>& ignorePaths,
-                    const std::filesystem::path&    rootDir) {
+                    const std::filesystem::path&    inputDir) {
   const auto rawPath = std::filesystem::path(d->getASTContext().getSourceManager().getFilename(d->getLocation()).str());
 
   // If the decl has an empty path, it's probably compiler-generated so we ignore it
@@ -110,10 +110,10 @@ bool isInIgnoreList(const clang::Decl*              d,
     return true;
   }
 
-  // Ignore paths outside of the rootDir
-  // ".." is used as a janky way to determine if the path is outside of rootDir since the canonicalized path
+  // Ignore paths outside of the inputDir
+  // ".." is used as a janky way to determine if the path is outside of inputDir since the canonicalized path
   // should not have any ".."s in it
-  const std::string relPath = std::filesystem::relative(std::filesystem::path(*absPath), rootDir).string();
+  const std::string relPath = std::filesystem::relative(std::filesystem::path(*absPath), inputDir).string();
   if (relPath.find("..") != std::string::npos) {
     return true;
   }

--- a/src/indexer/MatcherUtils.hpp
+++ b/src/indexer/MatcherUtils.hpp
@@ -10,7 +10,7 @@
 #include <string>
 
 /// @brief Update the name, line, and file of the decl
-void fillOutSymbol(hdoc::types::Symbol& s, const clang::NamedDecl* d, const std::filesystem::path& rootDir);
+void fillOutSymbol(hdoc::types::Symbol& s, const clang::NamedDecl* d, const std::filesystem::path& inputDir);
 
 /// @brief If the type is a specialized template, convert it to the original non-specialized
 /// templated type.
@@ -22,7 +22,7 @@ void findParentNamespace(hdoc::types::Symbol& s, const clang::NamedDecl* d);
 /// @brief Check if a decl is defined in a non-existent file or in the set of ignored paths
 bool isInIgnoreList(const clang::Decl*              d,
                     const std::vector<std::string>& ignorePaths,
-                    const std::filesystem::path&    rootDir);
+                    const std::filesystem::path&    inputDir);
 
 /// @brief Check if the decl is in an anonymous namespace
 bool isInAnonymousNamespace(const clang::Decl* d);

--- a/src/indexer/Matchers.cpp
+++ b/src/indexer/Matchers.cpp
@@ -48,7 +48,7 @@ void hdoc::indexer::matchers::FunctionMatcher::run(const clang::ast_matchers::Ma
 
   // Ignore invalid matches, matches in ignored files, and static functions
   if (res == nullptr || res->isOverloadedOperator() ||
-      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->rootDir) || !res->getSourceRange().isValid() ||
+      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->inputDir) || !res->getSourceRange().isValid() ||
       (res->isStatic() && !res->isCXXClassMember()) || isInAnonymousNamespace(res) ||
       (res->getAccess() == clang::AS_private && cfg->ignorePrivateMembers == true)) {
     return;
@@ -61,7 +61,7 @@ void hdoc::indexer::matchers::FunctionMatcher::run(const clang::ast_matchers::Ma
   this->index->functions.reserve(ID);
   hdoc::types::FunctionSymbol f;
   f.ID = ID;
-  fillOutSymbol(f, res, this->cfg->rootDir);
+  fillOutSymbol(f, res, this->cfg->inputDir);
 
   // Get a bunch of qualifiers
   f.isVariadic   = res->isVariadic();
@@ -149,7 +149,7 @@ void hdoc::indexer::matchers::RecordMatcher::run(const clang::ast_matchers::Matc
 
   // Ignore invalid matches
   if (res == nullptr || !res->isCompleteDefinition() || !res->getSourceRange().isValid() ||
-      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->rootDir) || isInAnonymousNamespace(res)) {
+      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->inputDir) || isInAnonymousNamespace(res)) {
     return;
   }
 
@@ -181,7 +181,7 @@ void hdoc::indexer::matchers::RecordMatcher::run(const clang::ast_matchers::Matc
   this->index->records.reserve(ID);
   hdoc::types::RecordSymbol c;
   c.ID = ID;
-  fillOutSymbol(c, res, this->cfg->rootDir);
+  fillOutSymbol(c, res, this->cfg->inputDir);
 
   // Apply the cached name found earlier for suspected typedef'ed decls
   if (c.name == "") {
@@ -195,7 +195,7 @@ void hdoc::indexer::matchers::RecordMatcher::run(const clang::ast_matchers::Matc
   // Get methods and decls (what's the difference?) for this record
   for (const auto* m : res->methods()) {
     if (m == nullptr || m->isImplicit() || m->isOverloadedOperator() ||
-        isInIgnoreList(m, this->cfg->ignorePaths, this->cfg->rootDir) || isInAnonymousNamespace(m) ||
+        isInIgnoreList(m, this->cfg->ignorePaths, this->cfg->inputDir) || isInAnonymousNamespace(m) ||
         (m->getAccess() == clang::AS_private && cfg->ignorePrivateMembers == true)) {
       continue;
     }
@@ -204,7 +204,7 @@ void hdoc::indexer::matchers::RecordMatcher::run(const clang::ast_matchers::Matc
   for (const auto* d : res->decls()) {
     if (const auto* ftd = llvm::dyn_cast<clang::FunctionTemplateDecl>(d)) {
       if (ftd == nullptr || ftd->isImplicit() || ftd->getAsFunction()->isOverloadedOperator() ||
-          isInIgnoreList(ftd, this->cfg->ignorePaths, this->cfg->rootDir) || isInAnonymousNamespace(ftd) ||
+          isInIgnoreList(ftd, this->cfg->ignorePaths, this->cfg->inputDir) || isInAnonymousNamespace(ftd) ||
           (ftd->getAccess() == clang::AS_private && cfg->ignorePrivateMembers == true)) {
         continue;
       }
@@ -363,7 +363,7 @@ void hdoc::indexer::matchers::EnumMatcher::run(const clang::ast_matchers::MatchF
 
   // Ignore invalid matches and anonymous enums
   if (res == nullptr || res->getNameAsString() == "" ||
-      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->rootDir) || isInAnonymousNamespace(res)) {
+      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->inputDir) || isInAnonymousNamespace(res)) {
     return;
   }
 
@@ -374,7 +374,7 @@ void hdoc::indexer::matchers::EnumMatcher::run(const clang::ast_matchers::MatchF
   this->index->enums.reserve(ID);
   hdoc::types::EnumSymbol e;
   e.ID = ID;
-  fillOutSymbol(e, res, this->cfg->rootDir);
+  fillOutSymbol(e, res, this->cfg->inputDir);
 
   if (const auto* parent = llvm::dyn_cast<clang::CXXRecordDecl>(res->getParent())) {
     e.name = parent->getNameAsString() + "::" + e.name;
@@ -425,7 +425,7 @@ void hdoc::indexer::matchers::NamespaceMatcher::run(const clang::ast_matchers::M
 
   // Ignore invalid matches and anonymous enums
   if (res == nullptr || res->getNameAsString() == "" ||
-      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->rootDir) || isInAnonymousNamespace(res)) {
+      isInIgnoreList(res, this->cfg->ignorePaths, this->cfg->inputDir) || isInAnonymousNamespace(res)) {
     return;
   }
 
@@ -436,7 +436,7 @@ void hdoc::indexer::matchers::NamespaceMatcher::run(const clang::ast_matchers::M
   this->index->namespaces.reserve(ID);
   hdoc::types::NamespaceSymbol n;
   n.ID = ID;
-  fillOutSymbol(n, res, this->cfg->rootDir);
+  fillOutSymbol(n, res, this->cfg->inputDir);
 
   findParentNamespace(n, res);
   this->index->namespaces.update(n.ID, n);

--- a/src/indexer/Matchers.hpp
+++ b/src/indexer/Matchers.hpp
@@ -14,7 +14,7 @@
 
 namespace hdoc::indexer::matchers {
 
-AST_MATCHER_P2(clang::Decl, shouldBeIgnored, std::vector<std::string>, ignoreList, std::filesystem::path, rootDir) {
+AST_MATCHER_P2(clang::Decl, shouldBeIgnored, std::vector<std::string>, ignoreList, std::filesystem::path, inputDir) {
   (void)Builder; // Avoid unused variable warning
   if (ignoreList.size() == 0) {
     return false;
@@ -31,7 +31,7 @@ AST_MATCHER_P2(clang::Decl, shouldBeIgnored, std::vector<std::string>, ignoreLis
     return false;
   }
 
-  auto filename = std::filesystem::relative(std::filesystem::path(fileEntry->getName().str()), rootDir).string();
+  auto filename = std::filesystem::relative(std::filesystem::path(fileEntry->getName().str()), inputDir).string();
   for (const auto& substr : ignoreList) {
     if (filename.find(substr) != std::string::npos) {
       return true;
@@ -59,7 +59,7 @@ public:
                    clang::ast_matchers::isTemplateInstantiation(),
                    clang::ast_matchers::isInstantiated(),
                    clang::ast_matchers::isExplicitTemplateSpecialization(),
-                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->rootDir))))
+                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->inputDir))))
         .bind("record");
   }
 };
@@ -82,7 +82,7 @@ public:
                    clang::ast_matchers::isTemplateInstantiation(),
                    clang::ast_matchers::isInstantiated(),
                    clang::ast_matchers::isExplicitTemplateSpecialization(),
-                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->rootDir))))
+                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->inputDir))))
         .bind("function");
   }
 };
@@ -103,7 +103,7 @@ public:
                    clang::ast_matchers::isInStdNamespace(),
                    clang::ast_matchers::isExpansionInSystemHeader(),
                    clang::ast_matchers::isImplicit(),
-                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->rootDir))))
+                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->inputDir))))
         .bind("enum");
   }
 };
@@ -122,7 +122,7 @@ public:
                    clang::ast_matchers::isInStdNamespace(),
                    clang::ast_matchers::isExpansionInSystemHeader(),
                    clang::ast_matchers::isImplicit(),
-                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->rootDir))))
+                   hdoc::indexer::matchers::shouldBeIgnored(this->cfg->ignorePaths, this->cfg->inputDir))))
         .bind("namespace");
   }
 };

--- a/src/support/ParallelExecutor.cpp
+++ b/src/support/ParallelExecutor.cpp
@@ -19,9 +19,9 @@ void hdoc::indexer::ParallelExecutor::execute(std::unique_ptr<clang::tooling::Fr
 
   std::vector<std::string> allFilesInCmpdb = this->cmpdb.getAllFiles();
 
-  if (this->debugLimitNumIndexedFiles > 0) {
-    allFilesInCmpdb.resize(this->debugLimitNumIndexedFiles);
-    totalNumFiles = std::to_string(this->debugLimitNumIndexedFiles);
+  if (this->config.debugLimitNumIndexedFiles > 0) {
+    allFilesInCmpdb.resize(this->config.debugLimitNumIndexedFiles);
+    totalNumFiles = std::to_string(this->config.debugLimitNumIndexedFiles);
   }
 
   for (const std::string& file : allFilesInCmpdb) {

--- a/src/support/ParallelExecutor.hpp
+++ b/src/support/ParallelExecutor.hpp
@@ -7,6 +7,7 @@
 
 #include "clang/Tooling/Execution.h"
 #include "llvm/Support/ThreadPool.h"
+#include "types/Config.hpp"
 
 namespace hdoc::indexer {
 /// @brief A cut-down reimplementation of clang's AllTUsToolExecutor.
@@ -19,8 +20,8 @@ public:
   ParallelExecutor(const clang::tooling::CompilationDatabase& cmpdb,
                    const std::vector<std::string>&            includePaths,
                    llvm::ThreadPool&                          pool,
-                   const uint32_t                             debugLimitNumIndexedFiles)
-      : cmpdb(cmpdb), includePaths(includePaths), pool(pool), debugLimitNumIndexedFiles(debugLimitNumIndexedFiles) {}
+                   const hdoc::types::Config&                             config)
+      : cmpdb(cmpdb), includePaths(includePaths), pool(pool), config(config) {}
 
   void execute(std::unique_ptr<clang::tooling::FrontendActionFactory> action);
 
@@ -28,6 +29,6 @@ private:
   const clang::tooling::CompilationDatabase& cmpdb;
   const std::vector<std::string>&            includePaths;
   llvm::ThreadPool&                          pool;
-  const uint32_t                             debugLimitNumIndexedFiles = 0;
+  const hdoc::types::Config&                 config;
 };
 } // namespace hdoc::indexer

--- a/src/types/Config.hpp
+++ b/src/types/Config.hpp
@@ -26,6 +26,7 @@ struct Config {
   std::filesystem::path    rootDir;                      ///< Path to the root of the repo directory where .hdoc.toml is
   std::filesystem::path    compileCommandsJSON;          ///< Path to compile_commands.json
   std::filesystem::path    outputDir;                    ///< Path of where documentation is saved
+  std::filesystem::path    inputDir;                     ///< Path of where source is located
   std::string              projectName;                  ///< Name of the project
   std::string              projectVersion;               ///< Project version
   std::string              timestamp;                    ///< Timestamp of this run


### PR DESCRIPTION
This is useful for the case of CI builds, where the configuration file is generated by the build system (e.g. meson) and placed in the build directory. As sometimes source directories are non-writeable, having this option allows for running hdoc in the directory of the config file while the source doesn't have to be at the CWD.